### PR TITLE
fix: Token-2022 support, UI polish, APR display

### DIFF
--- a/packages/cli/src/commands/close.ts
+++ b/packages/cli/src/commands/close.ts
@@ -21,15 +21,21 @@ import { getFlag, hasFlag, createRL, ask, formatStatus, solscanTxUrl, shortAddr 
 // Display positions table
 // ---------------------------------------------------------------------------
 
+function tokenSymbols(p: Position): [string, string] {
+  const parts = p.pool_name.split('-');
+  return parts.length >= 2 ? [parts[0], parts.slice(1).join('-')] : [p.token_x_mint.slice(0, 6), p.token_y_mint.slice(0, 6)];
+}
+
 function showPositions(positions: Position[]): void {
   console.log();
   for (let i = 0; i < positions.length; i++) {
     const p = positions[i];
+    const [sX, sY] = tokenSymbols(p);
     console.log(`  [${i + 1}] ${p.pool_name}  |  ${formatStatus(p.status)}`);
     console.log(`      Position: ${p.address}`);
     console.log(`      Pool:     ${p.pool}`);
-    console.log(`      Value:    ${p.current_value_x_ui.toFixed(4)} X  +  ${p.current_value_y_ui.toFixed(4)} Y`);
-    console.log(`      Fees:     ${p.fees_earned_x_ui.toFixed(6)} X  +  ${p.fees_earned_y_ui.toFixed(6)} Y`);
+    console.log(`      Value:    ${p.current_value_x_ui.toFixed(4)} ${sX}  +  ${p.current_value_y_ui.toFixed(4)} ${sY}`);
+    console.log(`      Fees:     ${p.fees_earned_x_ui.toFixed(6)} ${sX}  +  ${p.fees_earned_y_ui.toFixed(6)} ${sY}`);
     console.log(`      Range:    ${p.range_low.toFixed(6)} — ${p.range_high.toFixed(6)}  (${p.total_bins} bins)`);
     console.log();
   }
@@ -40,27 +46,25 @@ function showPositions(positions: Position[]): void {
 // ---------------------------------------------------------------------------
 
 function printCloseResult(result: ClosePositionResult): void {
+  const { token_x_symbol: sX, token_y_symbol: sY } = result;
   console.log(`
 Position closed!
 
-  Withdrawn X:    ${result.withdrawn_x}
-  Withdrawn Y:    ${result.withdrawn_y}
-  Claimed fees X: ${result.claimed_fees_x}
-  Claimed fees Y: ${result.claimed_fees_y}
-  TX:             ${solscanTxUrl(result.tx)}
+  Withdrawn:    ${result.withdrawn_x_ui.toFixed(4)} ${sX}  +  ${result.withdrawn_y_ui.toFixed(4)} ${sY}
+  Fees claimed: ${result.claimed_fees_x_ui.toFixed(6)} ${sX}  +  ${result.claimed_fees_y_ui.toFixed(6)} ${sY}
+  TX:           ${solscanTxUrl(result.tx)}
 `);
 }
 
 function printFundedCloseResult(result: FundedCloseResult): void {
+  const { token_x_symbol: sX, token_y_symbol: sY } = result.close;
   console.log(`
 Position closed!
 
-  Withdrawn X:    ${result.close.withdrawn_x}
-  Withdrawn Y:    ${result.close.withdrawn_y}
-  Claimed fees X: ${result.close.claimed_fees_x}
-  Claimed fees Y: ${result.close.claimed_fees_y}
-  Close TX:       ${solscanTxUrl(result.close.tx)}
-  Swap-back:      ${result.swaps.length} swap(s) executed
+  Withdrawn:    ${result.close.withdrawn_x_ui.toFixed(4)} ${sX}  +  ${result.close.withdrawn_y_ui.toFixed(4)} ${sY}
+  Fees claimed: ${result.close.claimed_fees_x_ui.toFixed(6)} ${sX}  +  ${result.close.claimed_fees_y_ui.toFixed(6)} ${sY}
+  Close TX:     ${solscanTxUrl(result.close.tx)}
+  Swap-back:    ${result.swaps.length} swap(s) executed
 `);
 
   for (const swap of result.swaps) {

--- a/packages/cli/src/commands/discover.ts
+++ b/packages/cli/src/commands/discover.ts
@@ -45,7 +45,9 @@ function fmtVol(n: number): string {
 }
 
 function fmtPct(n: number): string {
-  return `${n.toFixed(2)}%`;
+  if (n >= 10000) return `${(n / 1000).toFixed(0)}K%`;
+  if (n >= 1000) return `${(n / 1000).toFixed(1)}K%`;
+  return `${n.toFixed(0)}%`;
 }
 
 type Col = { header: string; width: number; get: (p: DiscoveredPool) => string; align: 'left' | 'right' };
@@ -55,7 +57,7 @@ const COLUMNS: Col[] = [
   { header: 'Pool',      width: 16, get: (p) => p.name, align: 'left' },
   { header: 'Address',   width: 9,  get: (p) => shortAddr(p.pool_address, 4, 3), align: 'left' },
   { header: 'Fees/Min',  width: 8,  get: (p) => fmtFee(p.avg_fee), align: 'right' },
-  { header: 'Fee/AcTVL', width: 9,  get: (p) => fmtPct(p.fee_active_tvl_ratio), align: 'right' },
+  { header: 'APR',       width: 9,  get: (p) => fmtPct(p.fee_active_tvl_ratio * 365), align: 'right' },
   { header: 'AcTVL',     width: 9,  get: (p) => formatMoney(p.active_tvl), align: 'right' },
   { header: 'Volat.',    width: 6,  get: (p) => p.volatility.toFixed(2), align: 'right' },
   { header: 'Swaps',     width: 6,  get: (p) => p.swap_count >= 1000 ? `${(p.swap_count / 1000).toFixed(1)}K` : String(Math.round(p.swap_count)), align: 'right' },

--- a/packages/cli/src/commands/open.ts
+++ b/packages/cli/src/commands/open.ts
@@ -83,16 +83,20 @@ export async function runOpen(args: string[]): Promise<void> {
     const poolMeta = await dlmm.getPoolMeta(pool);
     const balances = await wallet.getBalances();
 
+    // Resolve token symbols from cache
+    const symX = (lpcli.tokenRegistry.getCached(poolMeta.tokenXMint)?.symbol ?? poolMeta.tokenXMint.slice(0, 6)).toUpperCase();
+    const symY = (lpcli.tokenRegistry.getCached(poolMeta.tokenYMint)?.symbol ?? poolMeta.tokenYMint.slice(0, 6)).toUpperCase();
+
     const rl = createRL();
     console.log(`
 Open position on pool ${pool}:
-  Funding token:  ${funding.symbol} (${funding.mint.slice(0, 8)}...)
+  Funding token:  ${funding.symbol}
   Budget:         ${amountUi} ${funding.symbol}
-  Split ratio:    ${(ratioX * 100).toFixed(0)}% X / ${((1 - ratioX) * 100).toFixed(0)}% Y
+  Split ratio:    ${(ratioX * 100).toFixed(0)}% ${symX} / ${((1 - ratioX) * 100).toFixed(0)}% ${symY}
   Strategy:       ${strategy}
   Bin width:      ${widthBins !== undefined ? String(widthBins) : 'auto'}
-  Pool tokens:    X=${poolMeta.tokenXMint.slice(0, 8)}... / Y=${poolMeta.tokenYMint.slice(0, 8)}...
-  Active price:   ${poolMeta.activePrice.toFixed(6)} (X in Y terms)
+  Pool:           ${symX}-${symY}
+  Active price:   ${poolMeta.activePrice.toFixed(6)} ${symY} per ${symX}
   SOL balance:    ${balances.solBalance.toFixed(4)} SOL (${lpcli.config.feeReserveSol} SOL reserved for fees)
 `);
 
@@ -125,8 +129,7 @@ Position opened successfully!
 
   Position:    ${result.position.position}
   Range:       ${result.position.range_low.toFixed(6)} — ${result.position.range_high.toFixed(6)}
-  Deposited X: ${result.position.deposited_x}
-  Deposited Y: ${result.position.deposited_y}
+  Deposited:   ${result.position.deposited_x_ui.toFixed(4)} ${result.position.token_x_symbol}  +  ${result.position.deposited_y_ui.toFixed(4)} ${result.position.token_y_symbol}
   TX:          ${solscanTxUrl(result.position.tx)}
   Swaps:       ${result.swaps.length} swap(s) executed
 `);
@@ -186,8 +189,7 @@ Position opened successfully!
 
   Position:    ${result.position}
   Range:       ${result.range_low.toFixed(6)} — ${result.range_high.toFixed(6)}
-  Deposited X: ${result.deposited_x} (raw)
-  Deposited Y: ${result.deposited_y} (raw)
+  Deposited:   ${result.deposited_x_ui.toFixed(4)} ${result.token_x_symbol}  +  ${result.deposited_y_ui.toFixed(4)} ${result.token_y_symbol}
   TX:          ${solscanTxUrl(result.tx)}
 `);
 }

--- a/packages/cli/src/commands/swap.ts
+++ b/packages/cli/src/commands/swap.ts
@@ -209,17 +209,11 @@ async function runInteractive(wallet: WalletService): Promise<void> {
 
     execSpinner.stop(`Swap complete!`);
 
-    p.note(
-      [
-        `In:        ${result.inAmount} → Out: ${result.outAmount}`,
-        `Type:      ${result.swapType}`,
-        `Impact:    ${result.priceImpactPct}%`,
-        `TX:        ${solscanTxUrl(result.signature)}`,
-      ].join('\n'),
-      'Result',
-    );
-
-    p.outro('Done!');
+    console.log(`
+  In:      ${result.inAmount} → Out: ${result.outAmount}
+  Impact:  ${result.priceImpactPct}%
+  TX:      ${solscanTxUrl(result.signature)}
+`);
   } catch (err: unknown) {
     execSpinner.stop('Swap failed.');
     p.cancel(err instanceof Error ? err.message : String(err));

--- a/packages/core/src/dlmm.ts
+++ b/packages/core/src/dlmm.ts
@@ -590,12 +590,24 @@ export class DLMMService {
     const rangeLow = parseFloat(sdk.getPriceOfBinByBinId(finalMinBinId, finalBinStep).toString());
     const rangeHigh = parseFloat(sdk.getPriceOfBinByBinId(finalMaxBinId, finalBinStep).toString());
 
+    // Resolve token symbols and decimals from pool metadata
+    const meta = await this.getPoolMeta(params.pool);
+    const registry = this._options.tokenRegistry;
+    const tokenXSymbol = (registry?.getCached(meta.tokenXMint)?.symbol ?? meta.tokenXMint.slice(0, 6)).toUpperCase();
+    const tokenYSymbol = (registry?.getCached(meta.tokenYMint)?.symbol ?? meta.tokenYMint.slice(0, 6)).toUpperCase();
+    const rawX = params.amountX ?? 0;
+    const rawY = params.amountY ?? 0;
+
     return {
       position: positionKeypair.publicKey.toBase58(),
       range_low: rangeLow,
       range_high: rangeHigh,
-      deposited_x: params.amountX ?? 0,
-      deposited_y: params.amountY ?? 0,
+      deposited_x: rawX,
+      deposited_y: rawY,
+      deposited_x_ui: rawX / 10 ** meta.tokenXDecimals,
+      deposited_y_ui: rawY / 10 ** meta.tokenYDecimals,
+      token_x_symbol: tokenXSymbol,
+      token_y_symbol: tokenYSymbol,
       tx: signatures[signatures.length - 1],
     };
   }
@@ -633,11 +645,30 @@ export class DLMMService {
       },
     );
 
+    const tokenXDecimals = positionInfo.tokenX?.mint?.decimals ?? 6;
+    const tokenYDecimals = positionInfo.tokenY?.mint?.decimals ?? 6;
+    const tokenXMint = positionInfo.tokenX?.mint?.address?.toBase58() ?? '';
+    const tokenYMint = positionInfo.tokenY?.mint?.address?.toBase58() ?? '';
+    const registry = this._options.tokenRegistry;
+    const tokenXSymbol = (registry?.getCached(tokenXMint)?.symbol ?? tokenXMint.slice(0, 6)).toUpperCase();
+    const tokenYSymbol = (registry?.getCached(tokenYMint)?.symbol ?? tokenYMint.slice(0, 6)).toUpperCase();
+
+    const rawX = parseFloat(posData.totalXAmount);
+    const rawY = parseFloat(posData.totalYAmount);
+    const feesX = posData.feeX.toNumber();
+    const feesY = posData.feeY.toNumber();
+
     return {
-      withdrawn_x: parseFloat(posData.totalXAmount),
-      withdrawn_y: parseFloat(posData.totalYAmount),
-      claimed_fees_x: posData.feeX.toNumber(),
-      claimed_fees_y: posData.feeY.toNumber(),
+      withdrawn_x: rawX,
+      withdrawn_y: rawY,
+      withdrawn_x_ui: rawX / 10 ** tokenXDecimals,
+      withdrawn_y_ui: rawY / 10 ** tokenYDecimals,
+      claimed_fees_x: feesX,
+      claimed_fees_y: feesY,
+      claimed_fees_x_ui: feesX / 10 ** tokenXDecimals,
+      claimed_fees_y_ui: feesY / 10 ** tokenYDecimals,
+      token_x_symbol: tokenXSymbol,
+      token_y_symbol: tokenYSymbol,
       tx: signatures[signatures.length - 1],
     };
   }

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -327,6 +327,11 @@ export interface OpenPositionResult {
   range_high: number;
   deposited_x: number;
   deposited_y: number;
+  /** UI-friendly deposited amounts (decimal-adjusted). */
+  deposited_x_ui: number;
+  deposited_y_ui: number;
+  token_x_symbol: string;
+  token_y_symbol: string;
   tx: string;
 }
 
@@ -335,6 +340,13 @@ export interface ClosePositionResult {
   withdrawn_y: number;
   claimed_fees_x: number;
   claimed_fees_y: number;
+  /** UI-friendly amounts (decimal-adjusted). */
+  withdrawn_x_ui: number;
+  withdrawn_y_ui: number;
+  claimed_fees_x_ui: number;
+  claimed_fees_y_ui: number;
+  token_x_symbol: string;
+  token_y_symbol: string;
   tx: string;
 }
 

--- a/packages/core/src/wallet.ts
+++ b/packages/core/src/wallet.ts
@@ -15,6 +15,7 @@ import {
 } from '@solana/web3.js';
 import {
   TOKEN_PROGRAM_ID,
+  TOKEN_2022_PROGRAM_ID,
   getOrCreateAssociatedTokenAccount,
   createTransferInstruction,
   getAssociatedTokenAddress,
@@ -219,26 +220,34 @@ export class WalletService {
     const SOL = 'So11111111111111111111111111111111111111112';
     const unique = [...new Set(mints.filter(m => m !== SOL))];
 
-    // Derive all ATAs locally (zero RPC, pure math)
-    const atas = unique.map(mint =>
-      getAssociatedTokenAddressSync(new PublicKey(mint), this._publicKey),
+    // Derive ATAs for both legacy and Token-2022 programs
+    const legacyAtas = unique.map(mint =>
+      getAssociatedTokenAddressSync(new PublicKey(mint), this._publicKey, false, TOKEN_PROGRAM_ID),
+    );
+    const token2022Atas = unique.map(mint =>
+      getAssociatedTokenAddressSync(new PublicKey(mint), this._publicKey, false, TOKEN_2022_PROGRAM_ID),
     );
 
-    // Single RPC call: wallet account (for SOL lamports) + all ATAs
+    // Single RPC call: wallet + legacy ATAs + Token-2022 ATAs
     const accounts = await this.connection.getMultipleAccountsInfo([
       this._publicKey,
-      ...atas,
+      ...legacyAtas,
+      ...token2022Atas,
     ]);
 
     const solLamports = accounts[0]?.lamports ?? 0;
     const tokens: TokenBalance[] = [];
 
     for (let i = 0; i < unique.length; i++) {
-      const accountInfo = accounts[i + 1];
+      // Try legacy first, then Token-2022
+      const legacyAcct = accounts[1 + i];
+      const t2022Acct = accounts[1 + unique.length + i];
+      const accountInfo = (legacyAcct?.data && legacyAcct.data.length >= AccountLayout.span) ? legacyAcct : t2022Acct;
+
       if (!accountInfo?.data || accountInfo.data.length < AccountLayout.span) continue;
 
       const decoded = AccountLayout.decode(accountInfo.data);
-      const rawAmount = decoded.amount; // bigint
+      const rawAmount = decoded.amount;
       if (rawAmount === BigInt(0)) continue;
 
       const mint = unique[i];
@@ -265,14 +274,16 @@ export class WalletService {
    * Prefer getMintBalances() when you know which mints you need.
    */
   async getBalances(): Promise<WalletBalances> {
-    const solLamports = await this.connection.getBalance(this._publicKey);
+    // Fetch SOL + legacy tokens + Token-2022 tokens in parallel
+    const [solLamports, legacyAccounts, token2022Accounts] = await Promise.all([
+      this.connection.getBalance(this._publicKey),
+      this.connection.getParsedTokenAccountsByOwner(this._publicKey, { programId: TOKEN_PROGRAM_ID }),
+      this.connection.getParsedTokenAccountsByOwner(this._publicKey, { programId: TOKEN_2022_PROGRAM_ID }),
+    ]);
 
-    const tokenAccounts = await this.connection.getParsedTokenAccountsByOwner(
-      this._publicKey,
-      { programId: TOKEN_PROGRAM_ID }
-    );
+    const allAccounts = [...legacyAccounts.value, ...token2022Accounts.value];
 
-    const tokens: TokenBalance[] = tokenAccounts.value
+    const tokens: TokenBalance[] = allAccounts
       .map((ta) => {
         const info = ta.account.data.parsed.info;
         return {


### PR DESCRIPTION
## Summary
- **Token-2022 support** — wallet now queries both legacy and Token-2022 program IDs. Fixes Token-2022 tokens (e.g. UNC) being invisible to `lpcli swap` and causing `close` swap-back to silently return 0 swaps
- **UI amounts with symbols** — open/close/claim output shows `694.2 UNC + 0.142 SOL` instead of `694208519` raw and `X`/`Y` labels
- **APR column** in discover — replaces `Fee/AcTVL` with annualized APR (`daily_ratio * 365`)
- **Open confirmation** — shows `50% UNC / 50% SOL` and pool name instead of truncated mints
- **Swap output** — removed `@clack/prompts` borders from result display

## Test plan
- [x] `lpcli swap` — Token-2022 tokens now visible in token list
- [x] `lpcli meteora discover` — APR column shows annualized rates
- [ ] `lpcli meteora open` — confirmation shows token symbols
- [ ] `lpcli meteora close` — swap-back executes for Token-2022 tokens
- [ ] `lpcli meteora close` — output shows UI amounts with symbols

🤖 Generated with [Claude Code](https://claude.com/claude-code)